### PR TITLE
Drop author info from books table

### DIFF
--- a/db/migrate/20160911030615_drop_author_info_from_books.rb
+++ b/db/migrate/20160911030615_drop_author_info_from_books.rb
@@ -1,0 +1,10 @@
+class DropAuthorInfoFromBooks < ActiveRecord::Migration
+  def up
+    remove_column :books, :author_first_name
+    remove_column :books, :author_last_name
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160911004639) do
+ActiveRecord::Schema.define(version: 20160911030615) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,10 +33,8 @@ ActiveRecord::Schema.define(version: 20160911004639) do
   create_table "books", force: :cascade do |t|
     t.string   "title"
     t.string   "subtitle"
-    t.string   "author_first_name"
-    t.string   "author_last_name"
     t.string   "publisher"
-    t.string   "isbn",              limit: 18
+    t.string   "isbn",        limit: 18
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -1,8 +1,6 @@
 FactoryGirl.define do
   factory :book do
-    title             { 'The Alchemist' }
-    author_first_name { 'Paulo' }
-    author_last_name  { 'Coelho' }
-    isbn              { '978-0061122415' }
+    title { 'The Alchemist' }
+    isbn  { '978-0061122415' }
   end
 end


### PR DESCRIPTION
Completed the move to the new `Authors` table. Migration script (collection was small enough that an error hash is manageable, larger collections may need a different approach):

```ruby
errors = {}

Book.find_each do |book|
  begin
    author_first_name = book.author_first_name
    author_last_name = book.author_last_name
    book_author = Author.find_or_create_by(first_name: author_first_name, 
                                           last_name: author_last_name)

    book.authorships.create!(author: book_author)
  rescue => e
    errors[book.id] = e.message
  end
end
```

Related PRs: #31, #32, #33